### PR TITLE
iovnscli: Fix has-superuser bool flag bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+- iovnscli: fix has-superuser bool flag bug
+
 ## v0.2.4
 
 - domain grace period is time.duration now 

--- a/x/domain/client/cli/tx.go
+++ b/x/domain/client/cli/tx.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -562,7 +563,11 @@ func getCmdRegisterDomain(cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			hasSuperUser, err := cmd.Flags().GetBool("has-superuser")
+			hasSuperUserStr, err := cmd.Flags().GetString("has-superuser")
+			if err != nil {
+				return err
+			}
+			hasSuperUser, err := strconv.ParseBool(hasSuperUserStr)
 			if err != nil {
 				return err
 			}
@@ -589,7 +594,7 @@ func getCmdRegisterDomain(cdc *codec.Codec) *cobra.Command {
 	defaultDuration, _ := time.ParseDuration("1h")
 	// add flags
 	cmd.Flags().String("domain", "", "name of the domain you want to register")
-	cmd.Flags().Bool("has-superuser", true, "define if this domain has a superuser or not")
+	cmd.Flags().String("has-superuser", "true", "define if this domain has a superuser or not")
 	cmd.Flags().Duration("account-renew", defaultDuration, "account duration in seconds before expiration")
 	return cmd
 }


### PR DESCRIPTION
We came across this bug in weave before. The flag library is buggy. when you provide `--has-superuser true` it does not work instead you need to write `--has-superuser=true` which is not good UX wise.