### PR TITLE
Accept certificates as base64 json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - upgrade cosmos-sdk to v0.38.4
 - iovnsd: fix fee colletor address
+- iovnscli: certificates accepted in base64 json
 
 ## v0.2.5
 

--- a/x/domain/client/cli/tx.go
+++ b/x/domain/client/cli/tx.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bufio"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -354,7 +353,7 @@ func getCmdDelAccountCerts(cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return
 			}
-			cert, err := cmd.Flags().GetBytesHex("cert")
+			cert, err := cmd.Flags().GetBytesBase64("cert")
 			if err != nil {
 				return
 			}
@@ -380,8 +379,10 @@ func getCmdDelAccountCerts(cdc *codec.Codec) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				c = make([]byte, hex.EncodedLen(len(cfb)))
-				hex.Encode(c, cfb)
+				var c json.RawMessage
+				if err := json.Unmarshal(cfb, &c); err != nil {
+					return nil
+				}
 			}
 			// build msg
 			msg := &types.MsgDeleteAccountCertificate{
@@ -401,8 +402,8 @@ func getCmdDelAccountCerts(cdc *codec.Codec) *cobra.Command {
 	// add flags
 	cmd.Flags().String("domain", "", "domain name of the account")
 	cmd.Flags().String("name", "", "account name")
-	cmd.Flags().BytesHex("cert", []byte{}, "hex bytes of the certificate you want to delete")
-	cmd.Flags().String("cert-file", "", "directory of certificate file. File content will be encoded to hex")
+	cmd.Flags().BytesBase64("cert", []byte{}, "certificate you want to add in base64 encoded format")
+	cmd.Flags().String("cert-file", "", "directory of certificate file")
 	// return cmd
 	return cmd
 }
@@ -425,7 +426,7 @@ func getCmdAddAccountCerts(cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return
 			}
-			cert, err := cmd.Flags().GetBytesHex("cert")
+			cert, err := cmd.Flags().GetBytesBase64("cert")
 			if err != nil {
 				return
 			}
@@ -451,8 +452,10 @@ func getCmdAddAccountCerts(cdc *codec.Codec) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				c = make([]byte, hex.EncodedLen(len(cfb)))
-				hex.Encode(c, cfb)
+				var c json.RawMessage
+				if err := json.Unmarshal(cfb, &c); err != nil {
+					return nil
+				}
 			}
 
 			// build msg
@@ -473,8 +476,8 @@ func getCmdAddAccountCerts(cdc *codec.Codec) *cobra.Command {
 	// add flags
 	cmd.Flags().String("domain", "", "domain of the account")
 	cmd.Flags().String("name", "", "name of the account")
-	cmd.Flags().BytesHex("cert", []byte{}, "hex bytes of the certificate you want to add")
-	cmd.Flags().String("cert-file", "", "directory of certificate file. File content will be encoded to hex")
+	cmd.Flags().BytesBase64("cert", []byte{}, "certificate you want to add in base64 encoded format")
+	cmd.Flags().String("cert-file", "", "directory of certificate file")
 	// return cmd
 	return cmd
 }


### PR DESCRIPTION
Resolves https://github.com/iov-one/easy-testnets/issues/65
Resolves https://github.com/iov-one/iovns/issues/152

In the previous iteration, I wrote the tx domain cert functions to accept the certificate as hex. Now it is clear that we are accepting JSON format, we can just use base64 encoding. 