### PR TITLE
Revert gitian build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,7 @@ script:
     release_tag=$( [[ "$TRAVIS_TAG" != "" ]] && echo "yes" || echo "no" );
 
     if [[ $release_latest == "yes" || $release_tag == "yes" ]]; then
-    ./contrib/gitian-build.sh linux ;
-    mkdir build && tar -zxf $TRAVIS_BUILD_DIR/iovns-build-linux/build/out/iovns-${VERSION}-linux-amd64.tar.gz -C ${TRAVIS_BUILD_DIR}/build ;
+    make build
     docker build --pull --tag ${IMAGE_NAME} . ;
     fi;
 
@@ -90,16 +89,3 @@ branches:
     - master
     - /^v[0-9]+\.[0-9]+\.x$/
     - /^v[0-9]+\.[0-9]+\.[0-9]+$/
-
-deploy:
-  provider: releases
-  api_key:
-    ${GITHUB_API_KEY}
-  file:
-    - ${TRAVIS_BUILD_DIR}/iovns-build-linux/build/out/iovns-${VERSION}-linux-amd64.tar.gz
-    - ${TRAVIS_BUILD_DIR}/iovns-build-linux/build/out/src/iovns-${VERSION}.tar.gz
-    - ${TRAVIS_BUILD_DIR}/iovns-build-linux/result/iovns-linux-res.yml
-  skip_cleanup: true
-  on:
-    tags: true
-    condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$


### PR DESCRIPTION
!nochangelog

I thought this could happen... Normally we are supposed to run gitian builds on travis and deploy that build. Since we did not make iovns open source, gitian build cannot access the source code thus the build is failing. I reverted back the building phase to normal. We can enable this when we go open source.