### PR TITLE
Fix delete domain handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Remove account renew field in types.Domain
 - Improve json field names in msgs
 - Improve iovnscli tx add-certs error handling
+- Fix delete domain handler
 
 ## v0.3.0
 - fix account controller max renew exceed

--- a/x/domain/domain_handlers.go
+++ b/x/domain/domain_handlers.go
@@ -12,7 +12,7 @@ import (
 func handlerMsgDeleteDomain(ctx sdk.Context, k keeper.Keeper, msg *types.MsgDeleteDomain) (*sdk.Result, error) {
 	c := domain.NewController(ctx, k, msg.Domain)
 	// do precondition and authorization checks
-	if err := c.Validate(domain.MustExist, domain.Type(types.ClosedDomain), domain.DeletableBy(msg.Owner)); err != nil {
+	if err := c.Validate(domain.MustExist, domain.DeletableBy(msg.Owner)); err != nil {
 		return nil, err
 	}
 	// operation is allowed


### PR DESCRIPTION
Related to https://github.com/iov-one/easy-testnets/issues/97
Delete domain implementation did not match spec. Fixed it.
https://www.notion.so/SPEC-Type-open-a41abdec574a4810aa9acac3596553ed
https://www.notion.so/SPEC-Type-closed-9506e3a8b4114fb18b705d17730d1b90