### PR TITLE
Reconcile fee payer functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD
 
+### Breaking changes
+
+- Implement fee payer functionality
+
 ## v0.4.0
 
 - change reconciliate with new fee calculator spec

--- a/x/domain/account_handlers.go
+++ b/x/domain/account_handlers.go
@@ -33,7 +33,7 @@ func handlerMsgAddAccountCertificates(ctx sdk.Context, k keeper.Keeper, msg *typ
 		return nil, err
 	}
 	// collect fees
-	err := k.CollectFees(ctx, msg, msg.Owner, domainCtrl.Domain())
+	err := k.CollectFees(ctx, msg, domainCtrl.Domain())
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to collect fees")
 	}
@@ -63,7 +63,7 @@ func handlerMsgDeleteAccountCertificate(ctx sdk.Context, k keeper.Keeper, msg *t
 	); err != nil {
 		return nil, err
 	}
-	err := k.CollectFees(ctx, msg, msg.Owner, domainCtrl.Domain())
+	err := k.CollectFees(ctx, msg, domainCtrl.Domain())
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to collect fees")
 	}
@@ -87,7 +87,7 @@ func handlerMsgDeleteAccount(ctx sdk.Context, k keeper.Keeper, msg *types.MsgDel
 		return nil, err
 	}
 	// collect fees
-	err := k.CollectFees(ctx, msg, msg.Owner, domainCtrl.Domain())
+	err := k.CollectFees(ctx, msg, domainCtrl.Domain())
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to collect fees")
 	}
@@ -134,7 +134,7 @@ func handleMsgRegisterAccount(ctx sdk.Context, k keeper.Keeper, msg *types.MsgRe
 		a.ValidUntil = ctx.BlockTime().Add(conf.AccountRenewalPeriod).Unix()
 	}
 
-	err := k.CollectFees(ctx, msg, msg.Registerer, domainCtrl.Domain())
+	err := k.CollectFees(ctx, msg, domainCtrl.Domain())
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to collect fees")
 	}
@@ -157,7 +157,7 @@ func handlerMsgRenewAccount(ctx sdk.Context, k keeper.Keeper, msg *types.MsgRene
 		return nil, err
 	}
 	// collect fees
-	err := k.CollectFees(ctx, msg, msg.Signer, domainCtrl.Domain())
+	err := k.CollectFees(ctx, msg, domainCtrl.Domain())
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to collect fees")
 	}
@@ -197,7 +197,7 @@ func handlerMsgReplaceAccountTargets(ctx sdk.Context, k keeper.Keeper, msg *type
 		return nil, err
 	}
 	// collect fees
-	err := k.CollectFees(ctx, msg, msg.Owner, domainCtrl.Domain())
+	err := k.CollectFees(ctx, msg, domainCtrl.Domain())
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to collect fees")
 	}
@@ -224,7 +224,7 @@ func handlerMsgReplaceAccountMetadata(ctx sdk.Context, k keeper.Keeper, msg *typ
 		return nil, err
 	}
 	// collect fees
-	err := k.CollectFees(ctx, msg, msg.Owner, domainCtrl.Domain())
+	err := k.CollectFees(ctx, msg, domainCtrl.Domain())
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to collect fees")
 	}
@@ -258,7 +258,7 @@ func handlerMsgTransferAccount(ctx sdk.Context, k keeper.Keeper, msg *types.MsgT
 	}
 
 	// collect fees
-	err := k.CollectFees(ctx, msg, msg.Owner, domainCtrl.Domain())
+	err := k.CollectFees(ctx, msg, domainCtrl.Domain())
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to collect fees")
 	}

--- a/x/domain/client/cli/tx.go
+++ b/x/domain/client/cli/tx.go
@@ -75,12 +75,24 @@ func getCmdTransferDomain(cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return
 			}
+			feePayerStr, err := cmd.Flags().GetString("fee-payer")
+			if err != nil {
+				return err
+			}
+			var feePayer sdk.AccAddress
+			if feePayerStr != "" {
+				feePayer, err = sdk.AccAddressFromBech32(feePayerStr)
+				if err != nil {
+					return
+				}
+			}
 			// build msg
 			msg := &types.MsgTransferDomain{
 				Domain:       domain,
 				Owner:        cliCtx.GetFromAddress(),
 				NewAdmin:     newOwnerAddr,
 				TransferFlag: types.TransferFlag(transferFlag),
+				FeePayerAddr: feePayer,
 			}
 			// check if valid
 			if err = msg.ValidateBasic(); err != nil {
@@ -94,7 +106,7 @@ func getCmdTransferDomain(cdc *codec.Codec) *cobra.Command {
 	cmd.Flags().String("domain", "", "the domain name to transfer")
 	cmd.Flags().String("new-owner", "", "the new owner address in bech32 format")
 	cmd.Flags().Int("transfer-flag", types.ResetNone, fmt.Sprintf("transfer flags for a domain"))
-	//
+	cmd.Flags().String("fee-payer", "", "address of the fee payer, optional")
 	return cmd
 }
 
@@ -133,13 +145,25 @@ func getCmdTransferAccount(cdc *codec.Codec) *cobra.Command {
 			if resetBool, err = strconv.ParseBool(reset); err != nil {
 				return err
 			}
+			feePayerStr, err := cmd.Flags().GetString("fee-payer")
+			if err != nil {
+				return err
+			}
+			var feePayer sdk.AccAddress
+			if feePayerStr != "" {
+				feePayer, err = sdk.AccAddressFromBech32(feePayerStr)
+				if err != nil {
+					return
+				}
+			}
 			// build msg
 			msg := &types.MsgTransferAccount{
-				Domain:   domain,
-				Name:     name,
-				Owner:    cliCtx.GetFromAddress(),
-				NewOwner: newOwnerAddr,
-				Reset:    resetBool,
+				Domain:       domain,
+				Name:         name,
+				Owner:        cliCtx.GetFromAddress(),
+				NewOwner:     newOwnerAddr,
+				Reset:        resetBool,
+				FeePayerAddr: feePayer,
 			}
 			// check if valid
 			if err = msg.ValidateBasic(); err != nil {
@@ -154,7 +178,7 @@ func getCmdTransferAccount(cdc *codec.Codec) *cobra.Command {
 	cmd.Flags().String("name", "", "the name of the account you want to transfer")
 	cmd.Flags().String("new-owner", "", "the new owner address in bech32 format")
 	cmd.Flags().String("reset", "false", "true: reset all data associated with the account, false: preserves the data")
-	//
+	cmd.Flags().String("fee-payer", "", "address of the fee payer, optional")
 	return cmd
 }
 
@@ -191,12 +215,24 @@ func getCmdReplaceAccountTargets(cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return
 			}
+			feePayerStr, err := cmd.Flags().GetString("fee-payer")
+			if err != nil {
+				return err
+			}
+			var feePayer sdk.AccAddress
+			if feePayerStr != "" {
+				feePayer, err = sdk.AccAddressFromBech32(feePayerStr)
+				if err != nil {
+					return
+				}
+			}
 			// build msg
 			msg := &types.MsgReplaceAccountTargets{
-				Domain:     domain,
-				Name:       name,
-				NewTargets: targets,
-				Owner:      cliCtx.GetFromAddress(),
+				Domain:       domain,
+				Name:         name,
+				NewTargets:   targets,
+				Owner:        cliCtx.GetFromAddress(),
+				FeePayerAddr: feePayer,
 			}
 			// check if valid
 			if err = msg.ValidateBasic(); err != nil {
@@ -210,6 +246,7 @@ func getCmdReplaceAccountTargets(cdc *codec.Codec) *cobra.Command {
 	cmd.Flags().String("domain", "", "the domain name of account")
 	cmd.Flags().String("name", "", "the name of the account whose targets you want to replace")
 	cmd.Flags().String("src", "targets.json", "the file containing the new targets in json format")
+	cmd.Flags().String("fee-payer", "", "address of the fee payer, optional")
 	// return cmd
 	return cmd
 }
@@ -227,10 +264,22 @@ func getCmdDelDomain(cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return
 			}
+			feePayerStr, err := cmd.Flags().GetString("fee-payer")
+			if err != nil {
+				return err
+			}
+			var feePayer sdk.AccAddress
+			if feePayerStr != "" {
+				feePayer, err = sdk.AccAddressFromBech32(feePayerStr)
+				if err != nil {
+					return
+				}
+			}
 			// build msg
 			msg := &types.MsgDeleteDomain{
-				Domain: domain,
-				Owner:  cliCtx.GetFromAddress(),
+				Domain:       domain,
+				Owner:        cliCtx.GetFromAddress(),
+				FeePayerAddr: feePayer,
 			}
 			// check if valid
 			if err = msg.ValidateBasic(); err != nil {
@@ -242,7 +291,7 @@ func getCmdDelDomain(cdc *codec.Codec) *cobra.Command {
 	}
 	// add flags
 	cmd.Flags().String("domain", "", "name of the domain you want to delete")
-	//
+	cmd.Flags().String("fee-payer", "", "address of the fee payer, optional")
 	return cmd
 }
 
@@ -263,11 +312,23 @@ func getCmdDelAccount(cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return
 			}
+			feePayerStr, err := cmd.Flags().GetString("fee-payer")
+			if err != nil {
+				return err
+			}
+			var feePayer sdk.AccAddress
+			if feePayerStr != "" {
+				feePayer, err = sdk.AccAddressFromBech32(feePayerStr)
+				if err != nil {
+					return
+				}
+			}
 			// build msg
 			msg := &types.MsgDeleteAccount{
-				Domain: domain,
-				Name:   name,
-				Owner:  cliCtx.GetFromAddress(),
+				Domain:       domain,
+				Name:         name,
+				Owner:        cliCtx.GetFromAddress(),
+				FeePayerAddr: feePayer,
 			}
 			// check if valid
 			if err = msg.ValidateBasic(); err != nil {
@@ -280,7 +341,7 @@ func getCmdDelAccount(cdc *codec.Codec) *cobra.Command {
 	// add flags
 	cmd.Flags().String("domain", "", "the domain name of account")
 	cmd.Flags().String("name", "", "the name of the account you want to delete")
-	//
+	cmd.Flags().String("fee-payer", "", "address of the fee payer, optional")
 	return cmd
 }
 
@@ -297,10 +358,22 @@ func getCmdRenewDomain(cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return
 			}
+			feePayerStr, err := cmd.Flags().GetString("fee-payer")
+			if err != nil {
+				return err
+			}
+			var feePayer sdk.AccAddress
+			if feePayerStr != "" {
+				feePayer, err = sdk.AccAddressFromBech32(feePayerStr)
+				if err != nil {
+					return
+				}
+			}
 			// build msg
 			msg := &types.MsgRenewDomain{
-				Domain: domain,
-				Signer: cliCtx.GetFromAddress(),
+				Domain:       domain,
+				Signer:       cliCtx.GetFromAddress(),
+				FeePayerAddr: feePayer,
 			}
 			// check if valid
 			if err = msg.ValidateBasic(); err != nil {
@@ -312,6 +385,7 @@ func getCmdRenewDomain(cdc *codec.Codec) *cobra.Command {
 	}
 	// add flags
 	cmd.Flags().String("domain", "", "name of the domain you want to renew")
+	cmd.Flags().String("fee-payer", "", "address of the fee payer, optional")
 	// return
 	return cmd
 }
@@ -333,11 +407,23 @@ func getCmdRenewAccount(cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return
 			}
+			feePayerStr, err := cmd.Flags().GetString("fee-payer")
+			if err != nil {
+				return err
+			}
+			var feePayer sdk.AccAddress
+			if feePayerStr != "" {
+				feePayer, err = sdk.AccAddressFromBech32(feePayerStr)
+				if err != nil {
+					return
+				}
+			}
 			// build msg
 			msg := &types.MsgRenewAccount{
-				Domain: domain,
-				Name:   name,
-				Signer: cliCtx.GetFromAddress(),
+				Domain:       domain,
+				Name:         name,
+				Signer:       cliCtx.GetFromAddress(),
+				FeePayerAddr: feePayer,
 			}
 			// check if valid
 			if err = msg.ValidateBasic(); err != nil {
@@ -350,7 +436,7 @@ func getCmdRenewAccount(cdc *codec.Codec) *cobra.Command {
 	// add flags
 	cmd.Flags().String("domain", "", "domain name of the account")
 	cmd.Flags().String("name", "", "account name you want to renew")
-	// return
+	cmd.Flags().String("fee-payer", "", "address of the fee payer, optional")
 	return cmd
 }
 
@@ -403,12 +489,24 @@ func getCmdDelAccountCerts(cdc *codec.Codec) *cobra.Command {
 					return nil
 				}
 			}
+			feePayerStr, err := cmd.Flags().GetString("fee-payer")
+			if err != nil {
+				return err
+			}
+			var feePayer sdk.AccAddress
+			if feePayerStr != "" {
+				feePayer, err = sdk.AccAddressFromBech32(feePayerStr)
+				if err != nil {
+					return
+				}
+			}
 			// build msg
 			msg := &types.MsgDeleteAccountCertificate{
 				Domain:            domain,
 				Name:              name,
 				Owner:             cliCtx.GetFromAddress(),
 				DeleteCertificate: c,
+				FeePayerAddr:      feePayer,
 			}
 			// check if valid
 			if err = msg.ValidateBasic(); err != nil {
@@ -423,6 +521,7 @@ func getCmdDelAccountCerts(cdc *codec.Codec) *cobra.Command {
 	cmd.Flags().String("name", "", "account name")
 	cmd.Flags().BytesBase64("cert", []byte{}, "certificate you want to add in base64 encoded format")
 	cmd.Flags().String("cert-file", "", "directory of certificate file")
+	cmd.Flags().String("fee-payer", "", "address of the fee payer, optional")
 	// return cmd
 	return cmd
 }
@@ -475,13 +574,24 @@ func getCmdAddAccountCerts(cdc *codec.Codec) *cobra.Command {
 					return sdkerrors.Wrapf(ErrInvalidCertificate, "err: %s", err)
 				}
 			}
-
+			feePayerStr, err := cmd.Flags().GetString("fee-payer")
+			if err != nil {
+				return err
+			}
+			var feePayer sdk.AccAddress
+			if feePayerStr != "" {
+				feePayer, err = sdk.AccAddressFromBech32(feePayerStr)
+				if err != nil {
+					return
+				}
+			}
 			// build msg
 			msg := &types.MsgAddAccountCertificates{
 				Domain:         domain,
 				Name:           name,
 				Owner:          cliCtx.GetFromAddress(),
 				NewCertificate: c,
+				FeePayerAddr:   feePayer,
 			}
 			// check if valid
 			if err = msg.ValidateBasic(); err != nil {
@@ -496,7 +606,7 @@ func getCmdAddAccountCerts(cdc *codec.Codec) *cobra.Command {
 	cmd.Flags().String("name", "", "name of the account")
 	cmd.Flags().BytesBase64("cert", []byte{}, "certificate json you want to add in base64 encoded format")
 	cmd.Flags().String("cert-file", "", "directory of certificate file in json format")
-	// return cmd
+	cmd.Flags().String("fee-payer", "", "address of the fee payer, optional")
 	return cmd
 }
 
@@ -533,12 +643,24 @@ func getCmdRegisterAccount(cdc *codec.Codec) *cobra.Command {
 					return
 				}
 			}
+			feePayerStr, err := cmd.Flags().GetString("fee-payer")
+			if err != nil {
+				return err
+			}
+			var feePayer sdk.AccAddress
+			if feePayerStr != "" {
+				feePayer, err = sdk.AccAddressFromBech32(feePayerStr)
+				if err != nil {
+					return
+				}
+			}
 			// build msg
 			msg := &types.MsgRegisterAccount{
-				Domain:     domain,
-				Name:       name,
-				Owner:      ownerAddr,
-				Registerer: cliCtx.GetFromAddress(),
+				Domain:       domain,
+				Name:         name,
+				Owner:        ownerAddr,
+				Registerer:   cliCtx.GetFromAddress(),
+				FeePayerAddr: feePayer,
 			}
 			// check if valid
 			if err = msg.ValidateBasic(); err != nil {
@@ -551,6 +673,7 @@ func getCmdRegisterAccount(cdc *codec.Codec) *cobra.Command {
 	cmd.Flags().String("domain", "", "the existing domain name for your account")
 	cmd.Flags().String("name", "", "the name of your account")
 	cmd.Flags().String("owner", "", "the address of the owner, if no owner provided signer is the owner")
+	cmd.Flags().String("fee-payer", "", "address of the fee payer, optional")
 	return cmd
 }
 
@@ -571,14 +694,27 @@ func getCmdRegisterDomain(cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
 			if err := types.ValidateDomainType(types.DomainType(dType)); err != nil {
 				return err
 			}
+			feePayerStr, err := cmd.Flags().GetString("fee-payer")
+			if err != nil {
+				return err
+			}
+			var feePayer sdk.AccAddress
+			if feePayerStr != "" {
+				feePayer, err = sdk.AccAddressFromBech32(feePayerStr)
+				if err != nil {
+					return
+				}
+			}
 			msg := &types.MsgRegisterDomain{
-				Name:       domain,
-				Admin:      cliCtx.GetFromAddress(),
-				DomainType: types.DomainType(dType),
-				Broker:     nil,
+				Name:         domain,
+				Admin:        cliCtx.GetFromAddress(),
+				DomainType:   types.DomainType(dType),
+				Broker:       nil,
+				FeePayerAddr: feePayer,
 			}
 			// check if valid
 			if err = msg.ValidateBasic(); err != nil {
@@ -592,6 +728,7 @@ func getCmdRegisterDomain(cdc *codec.Codec) *cobra.Command {
 	// add flags
 	cmd.Flags().String("domain", "", "name of the domain you want to register")
 	cmd.Flags().String("type", types.ClosedDomain, "type of the domain")
+	cmd.Flags().String("fee-payer", "", "address of the fee payer, optional")
 	return cmd
 }
 
@@ -616,7 +753,7 @@ func getCmdSetAccountMetadata(cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			feePayerStr, err := cmd.Flags().GetString("feepayer")
+			feePayerStr, err := cmd.Flags().GetString("fee_payer")
 			if err != nil {
 				return err
 			}
@@ -631,7 +768,7 @@ func getCmdSetAccountMetadata(cdc *codec.Codec) *cobra.Command {
 				Domain:         domain,
 				Name:           name,
 				Owner:          cliCtx.GetFromAddress(),
-				FeePayer:       feePayer,
+				FeePayerAddr:   feePayer,
 				NewMetadataURI: metadata,
 			}
 			// check if valid
@@ -646,7 +783,7 @@ func getCmdSetAccountMetadata(cdc *codec.Codec) *cobra.Command {
 	cmd.Flags().String("domain", "", "the domain name of account")
 	cmd.Flags().String("name", "", "the name of the account whose targets you want to replace")
 	cmd.Flags().String("metadata", "", "the new metadata URI, leave empty to unset")
-	cmd.Flags().String("feepayer", "", "address of the fee payer, optional")
+	cmd.Flags().String("fee_payer", "", "address of the fee payer, optional")
 	// return cmd
 	return cmd
 }

--- a/x/domain/domain_handlers.go
+++ b/x/domain/domain_handlers.go
@@ -17,7 +17,7 @@ func handlerMsgDeleteDomain(ctx sdk.Context, k keeper.Keeper, msg *types.MsgDele
 	}
 	// operation is allowed
 	// collect fees
-	err := k.CollectFees(ctx, msg, msg.Owner, c.Domain())
+	err := k.CollectFees(ctx, msg, c.Domain())
 	if err != nil {
 		return nil, sdkerrors.Wrap(err, "unable to collect fees")
 	}
@@ -43,7 +43,7 @@ func handleMsgRegisterDomain(ctx sdk.Context, k Keeper, msg *types.MsgRegisterDo
 		Broker:     msg.Broker,
 	}
 	// collect fees
-	err = k.CollectFees(ctx, msg, msg.Admin, d)
+	err = k.CollectFees(ctx, msg, d)
 	if err != nil {
 		return nil, sdkerrors.Wrap(err, "unable to collect fees")
 	}
@@ -61,7 +61,7 @@ func handlerMsgRenewDomain(ctx sdk.Context, k keeper.Keeper, msg *types.MsgRenew
 		return nil, err
 	}
 	// collect fees
-	err = k.CollectFees(ctx, msg, msg.Signer, c.Domain())
+	err = k.CollectFees(ctx, msg, c.Domain())
 	if err != nil {
 		return nil, sdkerrors.Wrap(err, "unable to collect fees")
 	}
@@ -84,7 +84,7 @@ func handlerMsgTransferDomain(ctx sdk.Context, k keeper.Keeper, msg *types.MsgTr
 		return nil, err
 	}
 	// collect fees
-	err = k.CollectFees(ctx, msg, msg.Owner, c.Domain())
+	err = k.CollectFees(ctx, msg, c.Domain())
 	if err != nil {
 		return nil, sdkerrors.Wrap(err, "unable to collect fees")
 	}

--- a/x/domain/keeper/fees.go
+++ b/x/domain/keeper/fees.go
@@ -10,12 +10,12 @@ import (
 
 // CollectFees collects the fees of a msg and sends them
 // to the distribution module to validators and stakers
-func (k Keeper) CollectFees(ctx sdk.Context, msg sdk.Msg, addr sdk.AccAddress, domain types.Domain) error {
+func (k Keeper) CollectFees(ctx sdk.Context, msg types.MsgWithFeePayer, domain types.Domain) error {
 	moduleFees := k.ConfigurationKeeper.GetFees(ctx)
 	// create fee calculator
 	calculator := fees.NewController(ctx, k, moduleFees, domain)
 	// get fee
 	fee := calculator.GetFee(msg)
 	// transfer fee to distribution
-	return k.SupplyKeeper.SendCoinsFromAccountToModule(ctx, addr, auth.FeeCollectorName, sdk.NewCoins(fee))
+	return k.SupplyKeeper.SendCoinsFromAccountToModule(ctx, msg.FeePayer(), auth.FeeCollectorName, sdk.NewCoins(fee))
 }

--- a/x/domain/types/msgs.go
+++ b/x/domain/types/msgs.go
@@ -5,6 +5,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/errors"
 )
 
+type MsgWithFeePayer interface {
+	sdk.Msg
+	FeePayer() sdk.AccAddress
+}
+
 // MsgAddAccountCertificates is the message used
 // when a user wants to add new certificates
 // to his account
@@ -16,7 +21,18 @@ type MsgAddAccountCertificates struct {
 	// Owner is the owner of the account
 	Owner sdk.AccAddress `json:"owner"`
 	// NewCertificate is the new certificate to add
-	NewCertificate []byte `json:"new_certificate"`
+	NewCertificate []byte         `json:"new_certificate"`
+	FeePayerAddr   sdk.AccAddress `json:"fee_payer"`
+}
+
+var _ MsgWithFeePayer = (*MsgAddAccountCertificates)(nil)
+
+// Route implements sdk.Msg
+func (m *MsgAddAccountCertificates) FeePayer() sdk.AccAddress {
+	if !m.FeePayerAddr.Empty() {
+		return m.FeePayerAddr
+	}
+	return m.Owner
 }
 
 // Route implements sdk.Msg
@@ -50,7 +66,11 @@ func (m *MsgAddAccountCertificates) GetSignBytes() []byte {
 
 // GetSigners implements sdk.Msg
 func (m *MsgAddAccountCertificates) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{m.Owner}
+	if m.FeePayerAddr.Empty() {
+		return []sdk.AccAddress{m.Owner}
+	} else {
+		return []sdk.AccAddress{m.FeePayerAddr, m.Owner}
+	}
 }
 
 // MsgDeleteAccountCertificate is the request
@@ -64,7 +84,18 @@ type MsgDeleteAccountCertificate struct {
 	// DeleteCertificate is the certificate to delete
 	DeleteCertificate []byte `json:"delete_certificate"`
 	// Owner is the owner of the account
-	Owner sdk.AccAddress `json:"owner"`
+	Owner        sdk.AccAddress `json:"owner"`
+	FeePayerAddr sdk.AccAddress `json:"fee_payer"`
+}
+
+var _ MsgWithFeePayer = (*MsgDeleteAccountCertificate)(nil)
+
+// Route implements sdk.Msg
+func (m *MsgDeleteAccountCertificate) FeePayer() sdk.AccAddress {
+	if !m.FeePayerAddr.Empty() {
+		return m.FeePayerAddr
+	}
+	return m.Owner
 }
 
 // Route implements sdk.Msg
@@ -98,7 +129,11 @@ func (m *MsgDeleteAccountCertificate) GetSignBytes() []byte {
 
 // GetSigners implements sdk.Msg
 func (m *MsgDeleteAccountCertificate) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{m.Owner}
+	if m.FeePayerAddr.Empty() {
+		return []sdk.AccAddress{m.Owner}
+	} else {
+		return []sdk.AccAddress{m.FeePayerAddr, m.Owner}
+	}
 }
 
 // MsgDeleteAccount is the request model
@@ -109,7 +144,18 @@ type MsgDeleteAccount struct {
 	// Name is the name of the account
 	Name string `json:"name"`
 	// Owner is the owner of the account
-	Owner sdk.AccAddress `json:"owner"`
+	Owner        sdk.AccAddress `json:"owner"`
+	FeePayerAddr sdk.AccAddress `json:"fee_payer"`
+}
+
+var _ MsgWithFeePayer = (*MsgDeleteAccount)(nil)
+
+// Route implements sdk.Msg
+func (m *MsgDeleteAccount) FeePayer() sdk.AccAddress {
+	if !m.FeePayerAddr.Empty() {
+		return m.FeePayerAddr
+	}
+	return m.Owner
 }
 
 // Route implements sdk.Msg
@@ -144,14 +190,29 @@ func (m *MsgDeleteAccount) GetSignBytes() []byte {
 
 // GetSigners implements sdk.Msg
 func (m *MsgDeleteAccount) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{m.Owner}
+	if m.FeePayerAddr.Empty() {
+		return []sdk.AccAddress{m.Owner}
+	} else {
+		return []sdk.AccAddress{m.FeePayerAddr, m.Owner}
+	}
 }
 
 // MsgDeleteDomain is the request
 // model to delete a domain
 type MsgDeleteDomain struct {
-	Domain string         `json:"domain"`
-	Owner  sdk.AccAddress `json:"owner"`
+	Domain       string         `json:"domain"`
+	Owner        sdk.AccAddress `json:"owner"`
+	FeePayerAddr sdk.AccAddress `json:"fee_payer"`
+}
+
+var _ MsgWithFeePayer = (*MsgDeleteDomain)(nil)
+
+// Route implements sdk.Msg
+func (m *MsgDeleteDomain) FeePayer() sdk.AccAddress {
+	if !m.FeePayerAddr.Empty() {
+		return m.FeePayerAddr
+	}
+	return m.Owner
 }
 
 // Route implements sdk.Msg
@@ -183,7 +244,11 @@ func (m *MsgDeleteDomain) GetSignBytes() []byte {
 
 // GetSigners implements sdk.Msg
 func (m *MsgDeleteDomain) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{m.Owner}
+	if m.FeePayerAddr.Empty() {
+		return []sdk.AccAddress{m.Owner}
+	} else {
+		return []sdk.AccAddress{m.FeePayerAddr, m.Owner}
+	}
 }
 
 // MsgRegisterAccount is the request
@@ -200,7 +265,18 @@ type MsgRegisterAccount struct {
 	// Targets are the blockchain addresses of the account
 	Targets []BlockchainAddress `json:"targets"`
 	// Broker is the account that facilitated the transaction
-	Broker sdk.AccAddress `json:"broker"`
+	Broker       sdk.AccAddress `json:"broker"`
+	FeePayerAddr sdk.AccAddress `json:"fee_payer"`
+}
+
+var _ MsgWithFeePayer = (*MsgRegisterAccount)(nil)
+
+// Route implements sdk.Msg
+func (m *MsgRegisterAccount) FeePayer() sdk.AccAddress {
+	if !m.FeePayerAddr.Empty() {
+		return m.FeePayerAddr
+	}
+	return m.Registerer
 }
 
 // Route implements sdk.Msg
@@ -234,7 +310,11 @@ func (m *MsgRegisterAccount) GetSignBytes() []byte {
 
 // GetSigners implements sdk.Msg
 func (m *MsgRegisterAccount) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{m.Registerer}
+	if m.FeePayerAddr.Empty() {
+		return []sdk.AccAddress{m.Registerer}
+	} else {
+		return []sdk.AccAddress{m.FeePayerAddr, m.Registerer}
+	}
 }
 
 // MsgRegisterDomain is the request used to register new domains
@@ -242,12 +322,22 @@ type MsgRegisterDomain struct {
 	// Name is the name of the domain we want to register
 	Name string `json:"domain" arg:"--domain" helper:"name of the domain"`
 	// Admin is the address of the newly registered domain
-	Admin    sdk.AccAddress `json:"admin"`
-	FeePayer sdk.AccAddress `json:"fee_payer"`
+	Admin sdk.AccAddress `json:"admin"`
 	// DomainType defines the type of the domain
 	DomainType DomainType `json:"type"`
 	// Broker TODO document
-	Broker sdk.AccAddress `json:"broker" arg:"--broker" helper:"the broker"`
+	Broker       sdk.AccAddress `json:"broker" arg:"--broker" helper:"the broker"`
+	FeePayerAddr sdk.AccAddress `json:"fee_payer"`
+}
+
+var _ MsgWithFeePayer = (*MsgRegisterDomain)(nil)
+
+// Route implements sdk.Msg
+func (m *MsgRegisterDomain) FeePayer() sdk.AccAddress {
+	if !m.FeePayerAddr.Empty() {
+		return m.FeePayerAddr
+	}
+	return m.Admin
 }
 
 // Route implements sdk.Msg
@@ -279,7 +369,11 @@ func (m *MsgRegisterDomain) GetSignBytes() []byte {
 
 // GetSigners implements sdk.Msg
 func (m *MsgRegisterDomain) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{m.Admin}
+	if m.FeePayerAddr.Empty() {
+		return []sdk.AccAddress{m.Admin}
+	} else {
+		return []sdk.AccAddress{m.FeePayerAddr, m.Admin}
+	}
 }
 
 // MsgRenewAccount is the request
@@ -290,7 +384,18 @@ type MsgRenewAccount struct {
 	// Name is the name of the account
 	Name string `json:"name"`
 	// Configurer is the signer of the request
-	Signer sdk.AccAddress `json:"signer"`
+	Signer       sdk.AccAddress `json:"signer"`
+	FeePayerAddr sdk.AccAddress `json:"fee_payer"`
+}
+
+var _ MsgWithFeePayer = (*MsgRenewAccount)(nil)
+
+// Route implements sdk.Msg
+func (m *MsgRenewAccount) FeePayer() sdk.AccAddress {
+	if !m.FeePayerAddr.Empty() {
+		return m.FeePayerAddr
+	}
+	return m.Signer
 }
 
 // Route implements sdk.Msg
@@ -318,7 +423,11 @@ func (m *MsgRenewAccount) GetSignBytes() []byte {
 
 // GetSigners implements sdk.Msg
 func (m *MsgRenewAccount) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{m.Signer}
+	if m.FeePayerAddr.Empty() {
+		return []sdk.AccAddress{m.Signer}
+	} else {
+		return []sdk.AccAddress{m.FeePayerAddr, m.Signer}
+	}
 }
 
 // MsgRenewDomain is the request
@@ -327,7 +436,18 @@ type MsgRenewDomain struct {
 	// Domain is the domain name to renew
 	Domain string `json:"domain"`
 	// Configurer is the request signer
-	Signer sdk.AccAddress `json:"signer"`
+	Signer       sdk.AccAddress `json:"signer"`
+	FeePayerAddr sdk.AccAddress `json:"fee_payer"`
+}
+
+var _ MsgWithFeePayer = (*MsgRenewDomain)(nil)
+
+// Route implements sdk.Msg
+func (m *MsgRenewDomain) FeePayer() sdk.AccAddress {
+	if !m.FeePayerAddr.Empty() {
+		return m.FeePayerAddr
+	}
+	return m.Signer
 }
 
 // Route implements sdk.Msg
@@ -355,7 +475,11 @@ func (m *MsgRenewDomain) GetSignBytes() []byte {
 
 // GetSigners implements sdk.Msg
 func (m *MsgRenewDomain) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{m.Signer}
+	if m.FeePayerAddr.Empty() {
+		return []sdk.AccAddress{m.Signer}
+	} else {
+		return []sdk.AccAddress{m.FeePayerAddr, m.Signer}
+	}
 }
 
 // MsgReplaceAccountTargets is the request model
@@ -369,7 +493,18 @@ type MsgReplaceAccountTargets struct {
 	// NewTargets are the new blockchain addresses
 	NewTargets []BlockchainAddress `json:"new_targets"`
 	// Owner is the owner of the account
-	Owner sdk.AccAddress `json:"owner"`
+	Owner        sdk.AccAddress `json:"owner"`
+	FeePayerAddr sdk.AccAddress `json:"fee_payer"`
+}
+
+var _ MsgWithFeePayer = (*MsgReplaceAccountTargets)(nil)
+
+// Route implements sdk.Msg
+func (m *MsgReplaceAccountTargets) FeePayer() sdk.AccAddress {
+	if !m.FeePayerAddr.Empty() {
+		return m.FeePayerAddr
+	}
+	return m.Owner
 }
 
 // Route implements sdk.Msg
@@ -403,7 +538,11 @@ func (m *MsgReplaceAccountTargets) GetSignBytes() []byte {
 
 // GetSigners implements sdk.Msg
 func (m *MsgReplaceAccountTargets) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{m.Owner}
+	if m.FeePayerAddr.Empty() {
+		return []sdk.AccAddress{m.Owner}
+	} else {
+		return []sdk.AccAddress{m.FeePayerAddr, m.Owner}
+	}
 }
 
 // MsgReplaceAccountMetadata is the function used
@@ -417,8 +556,18 @@ type MsgReplaceAccountMetadata struct {
 	// we want to update or insert
 	NewMetadataURI string `json:"new_metadata_uri"`
 	// Owner is the owner of the account
-	Owner    sdk.AccAddress `json:"owner"`
-	FeePayer sdk.AccAddress `json:"fee_payer"`
+	Owner        sdk.AccAddress `json:"owner"`
+	FeePayerAddr sdk.AccAddress `json:"fee_payer"`
+}
+
+var _ MsgWithFeePayer = (*MsgReplaceAccountMetadata)(nil)
+
+// Route implements sdk.Msg
+func (m *MsgReplaceAccountMetadata) FeePayer() sdk.AccAddress {
+	if !m.FeePayerAddr.Empty() {
+		return m.FeePayerAddr
+	}
+	return m.Owner
 }
 
 // Route implements sdk.Msg
@@ -452,10 +601,10 @@ func (m *MsgReplaceAccountMetadata) GetSignBytes() []byte {
 
 // GetSigners implements sdk.Msg
 func (m *MsgReplaceAccountMetadata) GetSigners() []sdk.AccAddress {
-	if m.FeePayer == nil {
+	if m.FeePayerAddr.Empty() {
 		return []sdk.AccAddress{m.Owner}
 	} else {
-		return []sdk.AccAddress{m.FeePayer, m.Owner}
+		return []sdk.AccAddress{m.FeePayerAddr, m.Owner}
 	}
 }
 
@@ -471,7 +620,18 @@ type MsgTransferAccount struct {
 	// NewOwner is the new owner of the account
 	NewOwner sdk.AccAddress `json:"new_owner"`
 	// Reset indicates if the accounts content will be resetted
-	Reset bool `json:"reset"`
+	Reset        bool           `json:"reset"`
+	FeePayerAddr sdk.AccAddress `json:"fee_payer"`
+}
+
+var _ MsgWithFeePayer = (*MsgTransferAccount)(nil)
+
+// Route implements sdk.Msg
+func (m *MsgTransferAccount) FeePayer() sdk.AccAddress {
+	if !m.FeePayerAddr.Empty() {
+		return m.FeePayerAddr
+	}
+	return m.Owner
 }
 
 // Route implements sdk.Msg
@@ -509,7 +669,11 @@ func (m *MsgTransferAccount) GetSignBytes() []byte {
 
 // GetSigners implements sdk.Msg
 func (m *MsgTransferAccount) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{m.Owner}
+	if m.FeePayerAddr.Empty() {
+		return []sdk.AccAddress{m.Owner}
+	} else {
+		return []sdk.AccAddress{m.FeePayerAddr, m.Owner}
+	}
 }
 
 // TransferFlag defines the type of domain transfer
@@ -533,6 +697,17 @@ type MsgTransferDomain struct {
 	Owner        sdk.AccAddress `json:"owner"`
 	NewAdmin     sdk.AccAddress `json:"new_admin"`
 	TransferFlag TransferFlag   `json:"transfer_flag"`
+	FeePayerAddr sdk.AccAddress `json:"fee_payer"`
+}
+
+var _ MsgWithFeePayer = (*MsgTransferDomain)(nil)
+
+// Route implements sdk.Msg
+func (m *MsgTransferDomain) FeePayer() sdk.AccAddress {
+	if !m.FeePayerAddr.Empty() {
+		return m.FeePayerAddr
+	}
+	return m.Owner
 }
 
 // Route implements sdk.Msg
@@ -573,5 +748,9 @@ func (m *MsgTransferDomain) GetSignBytes() []byte {
 
 // GetSigners implements sdk.Msg
 func (m *MsgTransferDomain) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{m.Owner}
+	if m.FeePayerAddr.Empty() {
+		return []sdk.AccAddress{m.Owner}
+	} else {
+		return []sdk.AccAddress{m.FeePayerAddr, m.Owner}
+	}
 }


### PR DESCRIPTION
Resolves https://github.com/iov-one/iovns/issues/192
Resolves https://github.com/iov-one/iovns/issues/47

I tested the feature manually, it works. But I could not find a way to write unit tests to test fee payer functionality.

# How to produce:
## Initial state
user account: 
```
  address: star1em9fw954cgpv0rhkga2damur43k8gky8ska6yd
  coins:
  - denom: iov
    amount: "11111051"
  public_key: starpub1addwnpepqtwyh2vc2wwpu04vuvpm3zywdxgec98lmn4h0zvhm9459t8wslacqfrmem7
  account_number: 4
  sequence: 9
```
feepayer account:
```
  address: star1vsvlmhtndprs8ch0z2xy9zk4u4mu53yqtxp49a
  coins:
  - denom: iov
    amount: "11111101"
  public_key: starpub1addwnpepq22xpz9p0ygs52vtu87nf8paj760thml64ene86t9djyd7kxqq566qhlyrn
  account_number: 5
  sequence: 1
```

## Steps

```sh
iovnscli tx domain register-domain --domain test1 --from user 
iovnscli tx domain register-account --domain test1 --name test1 --from $(iovnscli keys show -a user) --fee-payer $(iovnscli keys show -a feepayer) --generate-only > reg-acc-tx.json
iovnscli tx sign reg-acc-tx.json --from user > user-signed-tx.json 
iovnscli tx sign user-signed-tx.json --from feepayer > feepayer-signed-tx.json
cat feepayer-signed-tx.json | jq > tx.json
```
After these steps `tx.json`:
```json
{
  "type": "cosmos-sdk/StdTx",
  "value": {
    "msg": [
      {
        "type": "domain/RegisterAccount",
        "value": {
          "domain": "test1",
          "name": "test1",
          "owner": "star1em9fw954cgpv0rhkga2damur43k8gky8ska6yd",
          "registerer": "star1em9fw954cgpv0rhkga2damur43k8gky8ska6yd",
          "targets": null,
          "broker": "",
          "fee_payer": "star1vsvlmhtndprs8ch0z2xy9zk4u4mu53yqtxp49a"
        }
      }
    ],
    "fee": {
      "amount": [],
      "gas": "200000"
    },
    "signatures": [
      {
        "pub_key": {
          "type": "tendermint/PubKeySecp256k1",
          "value": "AtxLqZhTnB4+rOMDuIiOaZGcFP/c63eJl9lrQqzuh/uA"
        },
        "signature": "tTpZoBX9AQOcCTFrL1dvEmcDz8youykAaAz5NPc/bLxjSCTxDIxp+Oj3hakXzxFBh2JnK2s3VeFP5HHLECD+Bw=="
      },
      {
        "pub_key": {
          "type": "tendermint/PubKeySecp256k1",
          "value": "ApRgiKF5EQopi+H9NJw9l7T133/VczyfSytkRvrGACmt"
        },
        "signature": "dCeKQDdEHxoekn/5cAs8BjY8vPzVx7lO9cdX6EZkQi4+Vg8egEoJyvOiF27tY39CKgXM9xjwfH2E+7gqJ2LtOg=="
      }
    ],
    "memo": ""
  }
}
```
There is one more step that needs to be done. FeePayer will pay the cosmos anti-spam tx fee it must be the first one in the **signature** array. Also `GetSigners` methods expects fee payers as the first. So with basic JSON manipulation switch the places of the signatures.
Last result:
```json
{
  "type": "cosmos-sdk/StdTx",
  "value": {
    "msg": [
      {
        "type": "domain/RegisterAccount",
        "value": {
          "domain": "test1",
          "name": "test1",
          "owner": "star1em9fw954cgpv0rhkga2damur43k8gky8ska6yd",
          "registerer": "star1em9fw954cgpv0rhkga2damur43k8gky8ska6yd",
          "targets": null,
          "broker": "",
          "fee_payer": "star1vsvlmhtndprs8ch0z2xy9zk4u4mu53yqtxp49a"
        }
      }
    ],
    "fee": {
      "amount": [],
      "gas": "200000"
    },
    "signatures": [
      {
        "pub_key": {
          "type": "tendermint/PubKeySecp256k1",
          "value": "ApRgiKF5EQopi+H9NJw9l7T133/VczyfSytkRvrGACmt"
        },
        "signature": "dCeKQDdEHxoekn/5cAs8BjY8vPzVx7lO9cdX6EZkQi4+Vg8egEoJyvOiF27tY39CKgXM9xjwfH2E+7gqJ2LtOg=="
      },
      {
        "pub_key": {
          "type": "tendermint/PubKeySecp256k1",
          "value": "AtxLqZhTnB4+rOMDuIiOaZGcFP/c63eJl9lrQqzuh/uA"
        },
        "signature": "tTpZoBX9AQOcCTFrL1dvEmcDz8youykAaAz5NPc/bLxjSCTxDIxp+Oj3hakXzxFBh2JnK2s3VeFP5HHLECD+Bw=="
      }
    ],
    "memo": ""
  }
}
```
Then: `iovnscli tx broadcast tx.json --broadcast-mode block`

## Last state
user:
```
  address: star1em9fw954cgpv0rhkga2damur43k8gky8ska6yd
  coins:
  - denom: iov
    amount: "11111051"
  public_key: starpub1addwnpepqtwyh2vc2wwpu04vuvpm3zywdxgec98lmn4h0zvhm9459t8wslacqfrmem7
  account_number: 4
  sequence: 10
```
fee payer:
```
  address: star1vsvlmhtndprs8ch0z2xy9zk4u4mu53yqtxp49a
  coins:
  - denom: iov
    amount: "11111091"
  public_key: starpub1addwnpepq22xpz9p0ygs52vtu87nf8paj760thml64ene86t9djyd7kxqq566qhlyrn
  account_number: 5
  sequence: 2
```