### PR TITLE
Return Success on success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
+
 ## HEAD
+
+## v0.9.2
+
 - add signature module
 - update docs
-## 0.9.1
+
+## v0.9.1
+
 - upgrade to cosmos sdk 0.39.1
 - fix empty account renewal
 - use external crud package
@@ -12,6 +18,7 @@
 - fix filtering when primary key is present
 - fix finding the smallest set in the filters
 - change enhance crud store api and make it more secure
+
 ## v0.9.0
 - add genesis file generation scripts
 - upgrade to cosmos sdk 0.39

--- a/x/signutil/cmd.go
+++ b/x/signutil/cmd.go
@@ -4,6 +4,11 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -12,13 +17,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
 	"github.com/spf13/cobra"
-	"io"
-	"io/ioutil"
-	"os"
-	"strings"
 )
 
-const DefaultChainID = "signCmd"
+const DefaultChainID = "signed-message-v1"
 const DefaultAccountNumber uint64 = 0
 const DefaultSequence uint64 = 0
 

--- a/x/signutil/rest.go
+++ b/x/signutil/rest.go
@@ -10,14 +10,14 @@ import (
 	"github.com/gorilla/mux"
 )
 
-type VerifyRequest struct {
-	ChainID       string     `json:"chain_id"`
-	AccountNumber uint64     `json:"account_number"`
-	Sequence      uint64     `json:"sequence"`
-	StdTx         auth.StdTx `json:"std_tx"`
+type Success struct {
+	Message  string `json:"message"`
+	Signer   string `json:"signer"`
+	Verified bool   `json:"verified"`
+	Signed   string `json:"signed"`
 }
 
-type Error struct {
+type Error struct { // TODO: use the sdk's REST utils
 	Code   uint64 `json:"code"`
 	Reason string `json:"error"`
 }
@@ -28,41 +28,62 @@ func RegisterRestRoutes(ctx context.CLIContext, r *mux.Router) {
 		b, err := ioutil.ReadAll(request.Body)
 		if err != nil {
 			writer.WriteHeader(http.StatusInternalServerError)
-			_, _ = writer.Write(cdc.MustMarshalJSON(Error{
+			_, _ = writer.Write(cdc.MustMarshalJSON(Error{ // TODO: log error on server
 				Code:   http.StatusInternalServerError,
 				Reason: err.Error(),
 			}))
 			return
 		}
-		var req VerifyRequest
+		var req auth.StdTx
 		err = cdc.UnmarshalJSON(b, &req)
 		if err != nil {
 			writer.WriteHeader(http.StatusBadRequest)
-			_, _ = writer.Write(cdc.MustMarshalJSON(Error{
+			_, _ = writer.Write(cdc.MustMarshalJSON(Error{ // TODO: log error on server
 				Code:   http.StatusBadRequest,
 				Reason: err.Error(),
 			}))
 			return
 		}
 
-		if req.ChainID == "" {
-			req.ChainID = DefaultChainID
-		}
-		if req.AccountNumber == 0 {
-			req.AccountNumber = DefaultAccountNumber
-		}
-		if req.Sequence == 0 {
-			req.Sequence = DefaultSequence
-		}
-
-		err = Verify(req.StdTx, req.ChainID, req.AccountNumber, req.Sequence)
+		err = Verify(req, DefaultChainID, DefaultAccountNumber, DefaultSequence)
 		if err != nil {
 			writer.WriteHeader(http.StatusUnauthorized)
-			_, _ = writer.Write(cdc.MustMarshalJSON(Error{
+			_, _ = writer.Write(cdc.MustMarshalJSON(Error{ // TODO: log error on server
 				Code:   http.StatusUnauthorized,
+				Reason: fmt.Sprintf("Did you sign with --chain-id '%s', --account-number %d, and --sequence %d?", DefaultChainID, DefaultAccountNumber, DefaultSequence),
+			}))
+			return
+		}
+
+		msgs := req.GetMsgs()
+		if len(msgs) != 1 {
+			writer.WriteHeader(http.StatusBadRequest)
+			_, _ = writer.Write(cdc.MustMarshalJSON(Error{ // TODO: log error on server
+				Code:   http.StatusBadRequest,
+				Reason: fmt.Sprintf("Expected 1 msg but got %d.", len(msgs)),
+			}))
+			return
+		}
+
+		var msg MsgSignText
+		err = cdc.UnmarshalJSON(msgs[0].GetSignBytes(), &msg)
+		if err != nil {
+			writer.WriteHeader(http.StatusBadRequest)
+			_, _ = writer.Write(cdc.MustMarshalJSON(Error{ // TODO: log error on server
+				Code:   http.StatusBadRequest,
 				Reason: err.Error(),
 			}))
 			return
 		}
+
+		// success
+		writer.WriteHeader(http.StatusOK) // TODO: unify response format with other successful REST responses in the starname module
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write(cdc.MustMarshalJSON(Success{ // TODO: log success on server
+			Message:  msg.Message,
+			Signer:   msg.Signer.String(),
+			Verified: true,
+			Signed:   string(b[:]),
+		}))
 	})
 }


### PR DESCRIPTION
The verify endpoint expects cosmos-sdk/StdTx json as the request body, eg `iovnscli tx sign message.json --chain-id signed-message-v1 --acount-number 0 --sequence 0 --offline --from star1... > signed.json && curl -X POST -d @signed.json http://localhost:1317/signutil/query/verify`.