### PR TITLE
update to cosmos-sdk v0.39.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/iov-one/iovns
 go 1.14
 
 require (
-	github.com/cosmos/cosmos-sdk v0.39.2-rc3
+	github.com/cosmos/cosmos-sdk v0.39.2
 	github.com/fatih/structs v1.1.0
 	github.com/golang/mock v1.3.1 // indirect
 	github.com/gorilla/mux v1.7.4

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cosmos/cosmos-sdk v0.39.1-rc1 h1:Xo+fkvs/4PEDOR1vb5XPbit5ZnP7OnqWYTNqtZ0lKPU=
 github.com/cosmos/cosmos-sdk v0.39.1-rc1/go.mod h1:soj4C8lIjJLeUQPBqrM+krbXdnF4cDKaaDgg1JIJYRU=
-github.com/cosmos/cosmos-sdk v0.39.2-rc3 h1:TbNPkGP2I7qP+XEYtimb6yj19QnGYZVVuSVg/5HLpYw=
-github.com/cosmos/cosmos-sdk v0.39.2-rc3/go.mod h1:VNUluciWBFj2vkhpMcp8rYZL/kCw0FtNc7SseUjE1KM=
+github.com/cosmos/cosmos-sdk v0.39.2 h1:nLfCJMkUuFt7ansi/YvCxwwxLFrgHCA3cYP4sJKYQdk=
+github.com/cosmos/cosmos-sdk v0.39.2/go.mod h1:VNUluciWBFj2vkhpMcp8rYZL/kCw0FtNc7SseUjE1KM=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d h1:49RLWk1j44Xu4fjHb6JFYmeUnDORVwHNkDxaQ0ctCVU=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/ledger-cosmos-go v0.11.1 h1:9JIYsGnXP613pb2vPjFeMMjBI5lEDsEaF6oYorTy6J4=


### PR DESCRIPTION
Hi @davepuchyr,

[Cosmos SDK v0.39.2 is out](https://blog.cosmos.network/cosmos-sdk-v0-39-2-is-out-278f35fb0240).
This updates the dependency to the final release.

Thanks for considering.